### PR TITLE
Fix the issue in the getDeviceTemplateEntities method returning non-deep copy objects

### DIFF
--- a/core/context/src/main/java/com/milesight/beaveriot/context/integration/entity/annotation/AnnotationEntityCache.java
+++ b/core/context/src/main/java/com/milesight/beaveriot/context/integration/entity/annotation/AnnotationEntityCache.java
@@ -4,6 +4,7 @@ import com.milesight.beaveriot.base.constants.StringConstant;
 import com.milesight.beaveriot.base.utils.StringUtils;
 import com.milesight.beaveriot.context.integration.model.Entity;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.util.ObjectUtils;
 
 import java.lang.reflect.Field;
@@ -36,7 +37,7 @@ public enum AnnotationEntityCache {
     }
 
     public List<Entity> getDeviceTemplateEntities(Class<?> clazz) {
-        return deviceTemplateEntitiesCache.get(clazz);
+        return deviceTemplateEntitiesCache.get(clazz) == null ? null : deviceTemplateEntitiesCache.get(clazz).stream().map(SerializationUtils::clone).toList();
     }
 
     public void cacheEntityMethod(Field filed, String key) {

--- a/core/context/src/main/java/com/milesight/beaveriot/context/integration/model/Entity.java
+++ b/core/context/src/main/java/com/milesight/beaveriot/context/integration/model/Entity.java
@@ -14,6 +14,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,7 +24,7 @@ import java.util.Optional;
  */
 @Getter
 @Setter
-public class Entity implements IdentityKey {
+public class Entity implements Serializable, IdentityKey {
 
     private Long id;
     private String deviceKey;


### PR DESCRIPTION
Fix the issue in the getDeviceTemplateEntities method of AnnotationEntityCache, where the returned non-deep copy objects caused the deviceKey template of the corresponding device entities to be overwritten when adding devices multiple times.