### PR TITLE
fix: db index lost and duplicated latest entity value

### DIFF
--- a/application/application-standard/src/main/resources/db/h2/changelog.yaml
+++ b/application/application-standard/src/main/resources/db/h2/changelog.yaml
@@ -11,3 +11,6 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: db/scheduler/h2/changelog.yaml
+  - includeAll:
+      path: sql/v1.2.1
+      relativeToChangelogFile: true

--- a/application/application-standard/src/main/resources/db/h2/sql/v1.2.1/entity.sql
+++ b/application/application-standard/src/main/resources/db/h2/sql/v1.2.1/entity.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset simon:entity_v1.2.1_20250522_093000
+DELETE FROM t_entity_latest
+WHERE id NOT IN (
+        SELECT id
+        FROM (
+            SELECT id, ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY id DESC) AS rn
+            FROM t_entity_latest
+        ) t
+        WHERE t.rn = 1
+);
+
+DROP INDEX IF EXISTS idx_entity_latest_entity_id;
+
+alter table t_entity_latest add constraint uk_entity_latest_entity_id unique(entity_id);
+
+CREATE INDEX idx_entity_history_entity_id_timestamp ON t_entity_history (entity_id, timestamp);

--- a/application/application-standard/src/main/resources/db/postgres/changelog.yaml
+++ b/application/application-standard/src/main/resources/db/postgres/changelog.yaml
@@ -11,3 +11,6 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: db/scheduler/postgres/changelog.yaml
+  - includeAll:
+      path: sql/v1.2.1
+      relativeToChangelogFile: true

--- a/application/application-standard/src/main/resources/db/postgres/sql/v1.2.1/entity.sql
+++ b/application/application-standard/src/main/resources/db/postgres/sql/v1.2.1/entity.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+--changeset simon:entity_v1.2.1_20250522_093000
+DELETE FROM t_entity_latest
+WHERE id NOT IN (
+        SELECT id
+        FROM (
+            SELECT id, ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY id DESC) AS rn
+            FROM t_entity_latest
+        ) t
+        WHERE t.rn = 1
+);
+
+DROP INDEX IF EXISTS idx_entity_latest_entity_id;
+
+alter table t_entity_latest add constraint uk_entity_latest_entity_id unique(entity_id);
+
+CREATE INDEX idx_entity_history_entity_id_timestamp ON t_entity_history (entity_id, timestamp);


### PR DESCRIPTION
* Fix `entity_latest` table duplicated with entity and add unique constraint
* Fix `entity_history` delete index without recreation in https://github.com/Milesight-IoT/beaver-iot/pull/112