### PR TITLE
feat: device template api parse

### DIFF
--- a/core/context/src/main/java/com/milesight/beaveriot/context/api/DeviceTemplateParserProvider.java
+++ b/core/context/src/main/java/com/milesight/beaveriot/context/api/DeviceTemplateParserProvider.java
@@ -1,6 +1,7 @@
 package com.milesight.beaveriot.context.api;
 
 import com.milesight.beaveriot.context.integration.model.ExchangePayload;
+import com.milesight.beaveriot.context.model.DeviceTemplateModel;
 import com.milesight.beaveriot.context.model.response.DeviceTemplateInputResult;
 import com.milesight.beaveriot.context.model.response.DeviceTemplateOutputResult;
 
@@ -11,6 +12,7 @@ import com.milesight.beaveriot.context.model.response.DeviceTemplateOutputResult
 public interface DeviceTemplateParserProvider {
     boolean validate(String deviceTemplateContent);
     String defaultContent();
+    DeviceTemplateModel parse(String deviceTemplateContent);
     DeviceTemplateInputResult input(String integration, Long deviceTemplateId, String jsonData);
     DeviceTemplateOutputResult output(String deviceKey, ExchangePayload payload);
 }

--- a/core/context/src/main/java/com/milesight/beaveriot/context/model/DeviceTemplateModel.java
+++ b/core/context/src/main/java/com/milesight/beaveriot/context/model/DeviceTemplateModel.java
@@ -1,4 +1,4 @@
-package com.milesight.beaveriot.devicetemplate.parser.model;
+package com.milesight.beaveriot.context.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.milesight.beaveriot.context.integration.model.config.EntityConfig;

--- a/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/enums/ServerErrorCode.java
+++ b/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/enums/ServerErrorCode.java
@@ -1,0 +1,73 @@
+package com.milesight.beaveriot.devicetemplate.enums;
+
+import com.milesight.beaveriot.base.exception.ErrorCodeSpec;
+import org.springframework.http.HttpStatus;
+
+/**
+ * author: Luxb
+ * create: 2025/6/16 10:00
+ **/
+public enum ServerErrorCode implements ErrorCodeSpec {
+    DEVICE_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "device_template_not_found", "Device template not found"),
+    DEVICE_TEMPLATE_EMPTY(HttpStatus.BAD_REQUEST.value(), "device_template_empty", "Device template empty"),
+    DEVICE_TEMPLATE_SCHEMA_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "device_template_schema_not_found", "Device template schema not found"),
+    DEVICE_TEMPLATE_VALIDATE_ERROR(HttpStatus.BAD_REQUEST.value(), "device_template_validate_error", "Device template validate error"),
+    DEVICE_TEMPLATE_DEFINITION_OUTPUT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "device_template_definition_output_not_found", "Device template definition output not found"),
+    DEVICE_ID_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "device_id_not_found", "Key device_id not found"),
+    DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "device_not_found", "Device not found"),
+    JSON_VALIDATE_ERROR(HttpStatus.BAD_REQUEST.value(), "json_validate_error", "Json validate error"),
+    DEVICE_ENTITY_VALUE_VALIDATE_ERROR(HttpStatus.BAD_REQUEST.value(), "device_entity_value_validate_error", "Device entity value validate error")
+    ;
+
+    private final String errorCode;
+    private String errorMessage;
+    private String detailMessage;
+    private int status = HttpStatus.INTERNAL_SERVER_ERROR.value();
+
+    ServerErrorCode(int status, String errorCode, String errorMessage, String detailMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+        this.detailMessage = detailMessage;
+    }
+
+    ServerErrorCode(int status, String errorCode) {
+        this.errorCode = errorCode;
+        this.status = status;
+    }
+
+    ServerErrorCode(int status, String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    ServerErrorCode(String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    ServerErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public String getDetailMessage() {
+        return detailMessage;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+}

--- a/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/parser/DeviceTemplateParserProviderImpl.java
+++ b/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/parser/DeviceTemplateParserProviderImpl.java
@@ -2,6 +2,7 @@ package com.milesight.beaveriot.devicetemplate.parser;
 
 import com.milesight.beaveriot.context.api.DeviceTemplateParserProvider;
 import com.milesight.beaveriot.context.integration.model.ExchangePayload;
+import com.milesight.beaveriot.context.model.DeviceTemplateModel;
 import com.milesight.beaveriot.context.model.response.DeviceTemplateInputResult;
 import com.milesight.beaveriot.context.model.response.DeviceTemplateOutputResult;
 import lombok.extern.slf4j.Slf4j;
@@ -38,5 +39,10 @@ public class DeviceTemplateParserProviderImpl implements DeviceTemplateParserPro
     @Override
     public DeviceTemplateOutputResult output(String deviceKey, ExchangePayload payload) {
         return deviceTemplateParser.output(deviceKey, payload);
+    }
+
+    @Override
+    public DeviceTemplateModel parse(String deviceTemplateContent) {
+        return deviceTemplateParser.parse(deviceTemplateContent);
     }
 }

--- a/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/service/DeviceTemplateServiceProviderImpl.java
+++ b/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/service/DeviceTemplateServiceProviderImpl.java
@@ -18,10 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -84,7 +81,7 @@ public class DeviceTemplateServiceProviderImpl implements DeviceTemplateServiceP
             deviceTemplatePO.setContent(deviceTemplate.getContent());
             shouldUpdate = true;
         }
-        if (!deviceTemplate.getDescription().equals(deviceTemplatePO.getDescription())) {
+        if (!Objects.equals(deviceTemplate.getDescription(), deviceTemplatePO.getDescription())) {
             deviceTemplatePO.setDescription(deviceTemplate.getDescription());
             shouldUpdate = true;
         }


### PR DESCRIPTION
Add: Introduce a new API `parser` component to process device templates, allowing retrieval of input and output schemas based on the template content.
Modify: Enhance the detail of error codes to meet the needs of the frontend.