### PR TITLE
fix: use Objects.equals() to check equality of the description in the entity

### DIFF
--- a/services/entity/entity-service/src/main/java/com/milesight/beaveriot/entity/service/EntityService.java
+++ b/services/entity/entity-service/src/main/java/com/milesight/beaveriot/entity/service/EntityService.java
@@ -373,7 +373,7 @@ public class EntityService implements EntityServiceProvider {
                     || dataEntityPO.getType() != entityPO.getType()
                     || !dataEntityPO.getName().equals(entityPO.getName())
                     || !dataEntityPO.getVisible().equals(entityPO.getVisible())
-                    || !dataEntityPO.getDescription().equals(entityPO.getDescription())) {
+                    || !Objects.equals(dataEntityPO.getDescription(), entityPO.getDescription())) {
                 entityPOList.add(entityPO);
             }
         });


### PR DESCRIPTION
Fix: Use Objects.equals() to check equality of the description in the entity