### PR TITLE
chore: extract the validation rule regex for the identifier

### DIFF
--- a/core/context/src/main/java/com/milesight/beaveriot/context/support/IdentifierValidator.java
+++ b/core/context/src/main/java/com/milesight/beaveriot/context/support/IdentifierValidator.java
@@ -10,8 +10,8 @@ import java.util.regex.Pattern;
  * @author leon
  */
 public class IdentifierValidator {
-
-    private static final Pattern pattern = Pattern.compile("^[A-Za-z0-9_@#$\\-/\\[\\]]+$");
+    public static final String regex = "^[A-Za-z0-9_@#$\\-/\\[\\]]+$";
+    private static final Pattern pattern = Pattern.compile(regex);
 
     private IdentifierValidator() {
     }


### PR DESCRIPTION
Extract the validation rule regex for the identifier so that other modules can reuse it.