### PR TITLE
chore: device status manager offline seconds supports null

### DIFF
--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/component/BlueprintLibrarySyncer.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/component/BlueprintLibrarySyncer.java
@@ -122,7 +122,6 @@ public class BlueprintLibrarySyncer {
         } catch (Exception e) {
             log.error("Sync blueprint library {} failed", blueprintLibraryAddress.getKey(), e);
             blueprintLibrary.setSyncStatus(BlueprintLibrarySyncStatus.SYNC_FAILED);
-            blueprintLibrary.setSyncedAt(System.currentTimeMillis());
             blueprintLibrary.setSyncMessage(MessageFormat.format("Sync failed. Error Message: {0}", e.getMessage()));
             blueprintLibraryService.save(blueprintLibrary);
             throw e;

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/controller/BlueprintLibrarySettingController.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/controller/BlueprintLibrarySettingController.java
@@ -15,6 +15,7 @@ import com.milesight.beaveriot.blueprint.library.service.BlueprintLibraryService
 import com.milesight.beaveriot.blueprint.library.service.BlueprintLibrarySubscriptionService;
 import com.milesight.beaveriot.context.model.BlueprintLibrary;
 import com.milesight.beaveriot.context.model.BlueprintLibrarySourceType;
+import com.milesight.beaveriot.context.model.BlueprintLibrarySyncStatus;
 import com.milesight.beaveriot.context.model.BlueprintLibraryType;
 import com.milesight.beaveriot.resource.manager.dto.ResourceRefDTO;
 import com.milesight.beaveriot.resource.manager.facade.ResourceManagerFacade;
@@ -61,7 +62,11 @@ public class BlueprintLibrarySettingController {
             response.setCurrentSourceType(BlueprintLibrarySourceType.Default.name());
             if (defaultBlueprintLibrary != null) {
                 response.setVersion(defaultBlueprintLibrary.getCurrentVersion());
-                response.setUpdateTime(defaultBlueprintLibrary.getSyncedAt());
+                boolean syncedSuccess = defaultBlueprintLibrary.getSyncStatus() == BlueprintLibrarySyncStatus.SYNCED;
+                if (syncedSuccess) {
+                    response.setUpdateTime(defaultBlueprintLibrary.getSyncedAt());
+                }
+                response.setSyncedSuccess(syncedSuccess);
             }
         }
 

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/enums/BlueprintLibraryAddressErrorCode.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/enums/BlueprintLibraryAddressErrorCode.java
@@ -20,6 +20,8 @@ public enum BlueprintLibraryAddressErrorCode implements ErrorCodeSpec {
             "blueprint_library_address_url_invalid", "Blueprint library address url must be a string that matches the pattern {0}"),
     BLUEPRINT_LIBRARY_ADDRESS_BRANCH_EMPTY(HttpStatus.BAD_REQUEST.value(),
             "blueprint_library_address_branch_empty", "Blueprint library address branch must not be empty"),
+    BLUEPRINT_LIBRARY_ADDRESS_ACCESS_FAILED(HttpStatus.BAD_REQUEST.value(),
+            "blueprint_library_address_access_failed", "Blueprint library address access failed"),
     BLUEPRINT_LIBRARY_ADDRESS_MANIFEST_NOT_REACHABLE(HttpStatus.BAD_REQUEST.value(),
             "blueprint_library_address_manifest_not_reachable", "Blueprint library address manifest is not reachable"),
     BLUEPRINT_LIBRARY_ADDRESS_MANIFEST_INVALID(HttpStatus.BAD_REQUEST.value(),

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/model/response/QueryBlueprintLibrarySettingResponse.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/model/response/QueryBlueprintLibrarySettingResponse.java
@@ -12,4 +12,5 @@ public class QueryBlueprintLibrarySettingResponse {
     private String fileName;
     private String version;
     private Long updateTime;
+    private boolean syncedSuccess;
 }

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/service/BlueprintLibraryAddressService.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/service/BlueprintLibraryAddressService.java
@@ -149,11 +149,11 @@ public class BlueprintLibraryAddressService {
     private String getManifestContentFromUrl(String manifestUrl) {
         ClientResponse response = OkHttpUtil.get(manifestUrl);
         if (response == null) {
-            return null;
+            throw ServiceException.with(BlueprintLibraryAddressErrorCode.BLUEPRINT_LIBRARY_ADDRESS_ACCESS_FAILED).build();
         }
 
         if (!response.isSuccessful()) {
-            return null;
+            throw ServiceException.with(BlueprintLibraryAddressErrorCode.BLUEPRINT_LIBRARY_ADDRESS_ACCESS_FAILED).build();
         }
 
         return response.getData();

--- a/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/constants/DeviceStatusConstants.java
+++ b/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/constants/DeviceStatusConstants.java
@@ -8,5 +8,4 @@ public class DeviceStatusConstants {
     public static final String IDENTIFIER_DEVICE_STATUS = "@status";
     public static final String STATUS_VALUE_ONLINE = "ONLINE";
     public static final String STATUS_VALUE_OFFLINE = "OFFLINE";
-    public static final long DEFAULT_OFFLINE_SECONDS = 300;
 }

--- a/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/local/DeviceStatusLocalManager.java
+++ b/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/local/DeviceStatusLocalManager.java
@@ -51,8 +51,10 @@ public class DeviceStatusLocalManager extends BaseDeviceStatusManager implements
         List<Device> devices = deviceServiceProvider.findAll(integrationId);
         if (config != null && !CollectionUtils.isEmpty(devices)) {
             devices.forEach(device -> {
-                long offlineSeconds = getDeviceOfflineSeconds(device, config);
-                startOfflineCountdown(device, offlineSeconds);
+                Long offlineSeconds = getDeviceOfflineSeconds(device, config);
+                if (offlineSeconds != null) {
+                    startOfflineCountdown(device, offlineSeconds);
+                }
             });
         }
     }
@@ -96,11 +98,14 @@ public class DeviceStatusLocalManager extends BaseDeviceStatusManager implements
         DeviceStatusConfig config = availableDeviceData.getDeviceStatusConfig();
         config.getOnlineUpdater().accept(device);
 
-        long offlineSeconds = getDeviceOfflineSeconds(device, config);
-        long expirationTime = System.currentTimeMillis() + offlineSeconds * 1000;
-        deviceExpirationTimeMap.put(device.getId(), expirationTime);
+        Long expirationTime = null;
+        Long offlineSeconds = getDeviceOfflineSeconds(device, config);
+        if (offlineSeconds != null) {
+            expirationTime = System.currentTimeMillis() + offlineSeconds * 1000;
+            deviceExpirationTimeMap.put(device.getId(), expirationTime);
+            startOfflineCountdown(device, offlineSeconds);
+        }
 
-        startOfflineCountdown(device, offlineSeconds);
         deviceOnlineCallback(device, expirationTime);
     }
 

--- a/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/redis/DeviceStatusRedisManager.java
+++ b/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/redis/DeviceStatusRedisManager.java
@@ -141,10 +141,14 @@ public class DeviceStatusRedisManager extends BaseDeviceStatusManager implements
         DeviceStatusConfig config = availableDeviceData.getDeviceStatusConfig();
         config.getOnlineUpdater().accept(device);
 
-        long offlineSeconds = getDeviceOfflineSeconds(device, config);
-        long expirationTime = System.currentTimeMillis() + offlineSeconds * 1000;
-        deviceExpirationTimeMap.put(device.getId(), expirationTime);
-        delayedQueue.offer(device.getId(), offlineSeconds, TimeUnit.SECONDS);
+        Long expirationTime = null;
+        Long offlineSeconds = getDeviceOfflineSeconds(device, config);
+        if (offlineSeconds != null) {
+            expirationTime = System.currentTimeMillis() + offlineSeconds * 1000;
+            deviceExpirationTimeMap.put(device.getId(), expirationTime);
+            delayedQueue.offer(device.getId(), offlineSeconds, TimeUnit.SECONDS);
+        }
+
         deviceOnlineCallback(device, expirationTime);
     }
 


### PR DESCRIPTION
Features:
1. The device status manager supports `null` for offline seconds
2. Modify the `BlueprintLibrarySettingController` GET API to include a synced success field in the response