### PR TITLE
fix: logic of default blueprint library

### DIFF
--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/controller/BlueprintLibrarySettingController.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/controller/BlueprintLibrarySettingController.java
@@ -22,6 +22,8 @@ import com.milesight.beaveriot.resource.manager.facade.ResourceManagerFacade;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Objects;
+
 /**
  * author: Luxb
  * create: 2025/9/17 15:05
@@ -116,7 +118,7 @@ public class BlueprintLibrarySettingController {
         if (blueprintLibrarySubscription == null) {
             blueprintLibrarySubscription = BlueprintLibrarySubscription.builder()
                     .libraryId(blueprintLibrary.getId())
-                    .libraryVersion(blueprintLibrary.getCurrentVersion())
+                    .libraryVersion(Objects.requireNonNullElse(blueprintLibrary.getCurrentVersion(), ""))
                     .active(false)
                     .build();
             blueprintLibrarySubscriptionService.save(blueprintLibrarySubscription);

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/model/BlueprintLibraryAddress.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/model/BlueprintLibraryAddress.java
@@ -18,15 +18,11 @@ import java.util.Objects;
 @Data
 public abstract class BlueprintLibraryAddress {
     public static final String RESOURCE_TYPE = "blueprint-library-address";
-    @JsonIgnore
-    protected Long id;
     protected BlueprintLibraryType type;
     protected String url;
     protected String branch;
     protected BlueprintLibrarySourceType sourceType;
     protected Boolean active;
-    @JsonIgnore
-    protected Long createdAt;
     @JsonIgnore
     private String key;
 

--- a/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/service/BlueprintLibraryAddressService.java
+++ b/services/blueprint/blueprint-service/src/main/java/com/milesight/beaveriot/blueprint/library/service/BlueprintLibraryAddressService.java
@@ -116,7 +116,9 @@ public class BlueprintLibraryAddressService {
             return null;
         }
 
-        return convertSubscriptionToAddress(blueprintLibrarySubscription);
+        BlueprintLibraryAddress address = convertSubscriptionToAddress(blueprintLibrarySubscription);
+        address.setActive(blueprintLibrarySubscription.getActive());
+        return address;
     }
 
     public BlueprintLibraryManifest validateAndGetManifest(BlueprintLibraryAddress blueprintLibraryAddress) {


### PR DESCRIPTION
Fix the logic of switching default blueprint library