### PR TITLE
chore: do not update device status to `OFFLINE` when its existing status is null

### DIFF
--- a/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/BaseDeviceStatusManager.java
+++ b/services/device/device-service/src/main/java/com/milesight/beaveriot/device/status/BaseDeviceStatusManager.java
@@ -123,10 +123,12 @@ public abstract class BaseDeviceStatusManager {
         }
 
         String existValue = (String) entityValueServiceProvider.findValueByKey(statusEntityKey);
-        if (!deviceStatus.equals(existValue)) {
-            ExchangePayload payload = ExchangePayload.create(statusEntityKey, deviceStatus);
-            entityValueServiceProvider.saveValuesAndPublishAsync(payload);
+        if (existValue == null && deviceStatus.equals(DeviceStatus.OFFLINE.name()) || deviceStatus.equals(existValue)) {
+            return;
         }
+
+        ExchangePayload payload = ExchangePayload.create(statusEntityKey, deviceStatus);
+        entityValueServiceProvider.saveValuesAndPublishAsync(payload);
     }
 
     protected String getStatusEntityKey(Device device) {


### PR DESCRIPTION
Do not update device status to `OFFLINE` when its existing status is null