### PR TITLE
fix: ignore entity validation when the entity is null

### DIFF
--- a/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/parser/DeviceTemplateParser.java
+++ b/services/device-template/device-template-service/src/main/java/com/milesight/beaveriot/devicetemplate/parser/DeviceTemplateParser.java
@@ -786,6 +786,10 @@ public class DeviceTemplateParser implements IDeviceTemplateParserFacade {
                     return null;
                 }
                 Object value = payload.get(entityKey);
+                if (value == null) {
+                    return null;
+                }
+
                 validateEntityValue(currentKey, entityKey, outputJsonObject.getType(), value);
                 return mapper.valueToTree(value);
             }


### PR DESCRIPTION
fix: ignore entity validation when the entity is null